### PR TITLE
Remove django-compressor storage

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.3.0
+==================
+* Remove django-compressor local_storage
+
 0.2.2 (2020-07-16)
 ==================
 * Update the seek of closed file fix to work with django-storages 1.9.x.

--- a/cacheds3storage/__init__.py
+++ b/cacheds3storage/__init__.py
@@ -1,16 +1,10 @@
 import os
-from django.core.files.storage import get_storage_class
 from storages.backends.s3boto3 import S3Boto3Storage, SpooledTemporaryFile
 from django.conf import settings
 from dateutil import tz
 
 
 class CachedS3BotoStorage(S3Boto3Storage):
-    def __init__(self, *args, **kwargs):
-        super(CachedS3BotoStorage, self).__init__(*args, **kwargs)
-        self.local_storage = get_storage_class(
-            'compressor.storage.CompressorFileStorage')()
-
     # https://github.com/jschneier/django-storages/issues/382
     #    #issuecomment-592876060
     def _save(self, name, content):
@@ -36,11 +30,6 @@ class CachedS3BotoStorage(S3Boto3Storage):
             # content_autoclose instance
             return super(CachedS3BotoStorage, self)._save(
                 name, content_autoclose)
-
-    def save(self, name, content):
-        name = super(CachedS3BotoStorage, self).save(name, content)
-        self.local_storage._save(name, content)
-        return name
 
     def modified_time(self, prefixed_path):
         # S3Boto3Storage returns a UTC timestamp (which it gets from S3)


### PR DESCRIPTION
It looks like this was initially set up via these docs: https://django-compressor.readthedocs.io/en/2.4.1/remote-storages/#using-staticfiles

This entire package may not even be necessary for our setup anymore. It's worth testing things with the vanilla
django-storages S3 storage class. It was initially set up to resolve a specific issue which may have been fixed
upstream by now - looks like there's still been some back and forth on this:

* https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#s3-5
* https://github.com/jschneier/django-storages/issues/382